### PR TITLE
Use testify assertions in domain tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,11 @@ require (
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/google/uuid v1.6.0
 	github.com/shopspring/decimal v1.4.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
 github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/domain/money_test.go
+++ b/internal/domain/money_test.go
@@ -1,0 +1,78 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMoney(t *testing.T) {
+	amount := decimal.NewFromFloat(100.50)
+	money, err := NewMoney("USD", amount)
+	assert.NoError(t, err)
+	assert.Equal(t, "USD", money.Currency)
+	assert.True(t, money.Amount.Equal(amount))
+}
+
+func TestNewMoneyValidation(t *testing.T) {
+	_, err := NewMoney("", decimal.NewFromInt(10))
+	assert.Error(t, err)
+	_, err = NewMoney("USD", decimal.Zero)
+	assert.ErrorIs(t, err, ErrInvalidAmount)
+}
+
+func TestMoneyAdd(t *testing.T) {
+	base, _ := NewMoney("USD", decimal.NewFromInt(50))
+	other, _ := NewMoney("USD", decimal.NewFromInt(25))
+
+	result, err := base.Add(other)
+	assert.NoError(t, err)
+	expected := decimal.NewFromInt(75)
+	assert.True(t, result.Amount.Equal(expected))
+}
+
+func TestMoneyAddCurrencyMismatch(t *testing.T) {
+	base, _ := NewMoney("USD", decimal.NewFromInt(50))
+	other, _ := NewMoney("EUR", decimal.NewFromInt(25))
+
+	_, err := base.Add(other)
+	assert.ErrorIs(t, err, ErrCurrencyMismatch)
+}
+
+func TestMoneySubtract(t *testing.T) {
+	base, _ := NewMoney("USD", decimal.NewFromInt(100))
+	other, _ := NewMoney("USD", decimal.NewFromInt(30))
+
+	result, err := base.Subtract(other)
+	assert.NoError(t, err)
+	expected := decimal.NewFromInt(70)
+	assert.True(t, result.Amount.Equal(expected))
+}
+
+func TestMoneySubtractValidation(t *testing.T) {
+	base, _ := NewMoney("USD", decimal.NewFromInt(30))
+	larger, _ := NewMoney("USD", decimal.NewFromInt(40))
+	otherCurrency, _ := NewMoney("EUR", decimal.NewFromInt(10))
+
+	_, err := base.Subtract(larger)
+	assert.ErrorIs(t, err, ErrInvalidAmount)
+	_, err = base.Subtract(otherCurrency)
+	assert.ErrorIs(t, err, ErrCurrencyMismatch)
+}
+
+func TestMoneyMultiply(t *testing.T) {
+	base, _ := NewMoney("USD", decimal.NewFromFloat(10.25))
+	factor := decimal.NewFromFloat(1.5)
+
+	result := base.Multiply(factor)
+	expected := decimal.RequireFromString("15.375")
+	assert.True(t, result.Amount.Equal(expected))
+	assert.Equal(t, base.Currency, result.Currency)
+}
+
+func TestZeroMoney(t *testing.T) {
+	zero := ZeroMoney("GBP")
+	assert.Equal(t, "GBP", zero.Currency)
+	assert.True(t, zero.Amount.Equal(decimal.Zero))
+}

--- a/internal/domain/wallet_test.go
+++ b/internal/domain/wallet_test.go
@@ -1,0 +1,51 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWalletDebit(t *testing.T) {
+	balance, _ := NewMoney("USD", decimal.NewFromInt(100))
+	wallet := Wallet{ID: "w1", Currency: "USD", Balance: balance}
+	debit, _ := NewMoney("USD", decimal.NewFromInt(60))
+
+	err := wallet.Debit(debit)
+	assert.NoError(t, err)
+	expected := decimal.NewFromInt(40)
+	assert.True(t, wallet.Balance.Amount.Equal(expected))
+}
+
+func TestWalletDebitValidation(t *testing.T) {
+	balance, _ := NewMoney("USD", decimal.NewFromInt(50))
+	wallet := Wallet{ID: "w1", Currency: "USD", Balance: balance}
+	mismatch, _ := NewMoney("EUR", decimal.NewFromInt(10))
+	oversized, _ := NewMoney("USD", decimal.NewFromInt(60))
+
+	err := wallet.Debit(mismatch)
+	assert.ErrorIs(t, err, ErrCurrencyMismatchWallet)
+	err = wallet.Debit(oversized)
+	assert.ErrorIs(t, err, ErrInsufficientFunds)
+}
+
+func TestWalletCredit(t *testing.T) {
+	balance, _ := NewMoney("USD", decimal.NewFromInt(20))
+	wallet := Wallet{ID: "w1", Currency: "USD", Balance: balance}
+	credit, _ := NewMoney("USD", decimal.NewFromInt(30))
+
+	err := wallet.Credit(credit)
+	assert.NoError(t, err)
+	expected := decimal.NewFromInt(50)
+	assert.True(t, wallet.Balance.Amount.Equal(expected))
+}
+
+func TestWalletCreditCurrencyMismatch(t *testing.T) {
+	balance, _ := NewMoney("USD", decimal.NewFromInt(20))
+	wallet := Wallet{ID: "w1", Currency: "USD", Balance: balance}
+	credit, _ := NewMoney("EUR", decimal.NewFromInt(5))
+
+	err := wallet.Credit(credit)
+	assert.ErrorIs(t, err, ErrCurrencyMismatchWallet)
+}


### PR DESCRIPTION
## Summary
- add testify as a testing dependency for assertion helpers
- update money and wallet domain tests to use testify assert helpers for clearer expectations

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68dce95b45e88324ba052e433252b5e4